### PR TITLE
Enforce minimum word count on feature requests

### DIFF
--- a/app/form.tsx
+++ b/app/form.tsx
@@ -70,6 +70,10 @@ function Item({
   );
 }
 
+function validateWordCount(inputValue) {
+  return inputValue.trim().split(/\s+/).length >= 10;
+}
+
 type FeatureState = {
   newFeature: Feature;
   updatedFeature?: Feature;
@@ -129,9 +133,16 @@ export default function FeatureForm({ features }: { features: Feature[] }) {
           onSubmit={(event) => {
             event.preventDefault();
             let formData = new FormData(event.currentTarget);
+            let featureInputValue = formData.get("feature") as string;
+
+            if (!validateWordCount(featureInputValue)) {
+              alert("Feature request must contain at least 10 words.");
+              return;
+            }
+
             let newFeature = {
               ...featureStub,
-              title: formData.get("feature") as string,
+              title: featureInputValue,
             };
 
             formRef.current?.reset();


### PR DESCRIPTION
Related to #2

Implements a minimum word count validation for feature request inputs in the roadmap request form.

- **Validation Function Added**: Introduces a new function `validateWordCount` to check if the input contains at least 10 words. This function is utilized during the form submission process to ensure the input meets the minimum word count requirement.
- **Form Submission Modification**: Modifies the `onSubmit` event handler within the `FeatureForm` component to invoke the `validateWordCount` function. If the input does not meet the minimum word count, an alert is displayed to the user, and the form submission is halted.
- **User Feedback**: Utilizes a browser alert to inform users when their feature request does not meet the minimum word count requirement, enhancing user experience by providing immediate feedback.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/atian25/redis-roadmap/issues/2?shareId=d1b71803-10ff-4efd-bdd6-a502d9867088).