### PR TITLE
Add status check router and page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ The example is a roadmap voting application where users can enter and vote for f
 - Users can add and upvote items (features in the roadmap)
 - Users can enter their email addresses to be notified about the released items.
 
+## New Feature: Website Status Check
+
+We've introduced a new `/status` router that sends HTTP requests to check the status of configurable websites every 1 minute. The newest status of these websites is displayed on the `/status` page, allowing users to monitor the availability of their favorite sites in real-time.
+
+### Configuring Websites for Status Checks
+
+To configure the websites you want to monitor, update the `vercel.json` configuration file with the URLs of the websites. This setup allows for easy customization and deployment through Vercel.
+
 ## Demo
 
 - [https://roadmap-redis.vercel.app/](https://roadmap-redis.vercel.app/)

--- a/pages/api/status.ts
+++ b/pages/api/status.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fetch from 'node-fetch';
+import { URL } from 'url';
+
+// Scheduled task to check the status of websites every 1 minute
+const checkWebsiteStatus = async () => {
+  const websites = process.env.WEBSITES ? process.env.WEBSITES.split(',') : [];
+  const statuses = await Promise.all(
+    websites.map(async (website) => {
+      try {
+        const response = await fetch(new URL(website));
+        return { website, status: response.status };
+      } catch (error) {
+        return { website, status: 'Error', error: error.message };
+      }
+    })
+  );
+  return statuses;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method === 'GET') {
+    const statuses = await checkWebsiteStatus();
+    res.status(200).json({ statuses });
+  } else {
+    res.setHeader('Allow', ['GET']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+const StatusPage = () => {
+  const [statuses, setStatuses] = useState([]);
+
+  useEffect(() => {
+    const fetchStatuses = async () => {
+      const response = await fetch('/api/status');
+      const data = await response.json();
+      setStatuses(data.statuses);
+    };
+
+    fetchStatuses();
+    const interval = setInterval(fetchStatuses, 60000); // Refresh every 1 minute
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div>
+      <h1>Website Statuses</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Website</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {statuses.map((status, index) => (
+            <tr key={index}>
+              <td>{status.website}</td>
+              <td>{status.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default StatusPage;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,23 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "next.config.js",
+      "use": "@vercel/next"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api/status",
+      "dest": "/api/status.js",
+      "methods": ["GET"]
+    },
+    {
+      "src": "/status",
+      "dest": "/status.js"
+    }
+  ],
+  "env": {
+    "WEBSITES": "https://example.com,https://anotherexample.com"
+  }
+}


### PR DESCRIPTION
Related to #5

Adds a new `/status` router and page to check and display the status of configurable websites every 1 minute.

- **API Route Implementation**: Adds `pages/api/status.ts` to handle status checks. This file includes a function to fetch the status of websites specified in the `WEBSITES` environment variable, and returns their HTTP status codes or error messages.
- **Status Page Creation**: Adds `pages/status.tsx` to display the status of websites. This page fetches the latest status from the `/api/status` endpoint every 1 minute and displays it in a table format.
- **Documentation Update**: Updates `README.md` to include information about the new `/status` router, its functionality, and how to configure websites for status checks in the `vercel.json` file.
- **Deployment Configuration**: Adds `vercel.json` to configure the deployment on Vercel, including routes for the new API and page, and an environment variable for website URLs to monitor.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/atian25/redis-roadmap/issues/5?shareId=ba1528a7-1f33-432e-b5c4-6434331ad283).